### PR TITLE
fix unused warning

### DIFF
--- a/examples/tcp_test.rs
+++ b/examples/tcp_test.rs
@@ -13,5 +13,5 @@ fn main() {
       tag: "foo",
     };
 
-    fluentd.write(&obj);
+    let _ = fluentd.write(&obj);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,6 @@ mod test {
             tag: "foo",
         };
 
-        fluentd.write(&object);
+        let _ = fluentd.write(&object);
     }
 }


### PR DESCRIPTION
fix `warning: unused result which must be used, #[warn(unused_must_use)] on by default`
