### PR TITLE
tcp: Provide ::new()

### DIFF
--- a/examples/tcp_test.rs
+++ b/examples/tcp_test.rs
@@ -8,10 +8,7 @@ fn main() {
     let mut obj: HashMap<String, String> = HashMap::new();
     obj.insert("key".to_string(), "value".to_string());
 
-    let fluentd = tcp::Fluentd {
-      address: "0.0.0.0:24224",
-      tag: "foo",
-    };
+    let fluentd = tcp::Fluentd::new("0.0.0.0:24224","foo");
 
     let _ = fluentd.write(&obj);
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -34,6 +34,13 @@ impl From<json::EncoderError> for FluentError {
 
 
 impl <'a, A: net::ToSocketAddrs> Fluentd<'a, A> {
+    pub fn new(address: A, tag: &'a str) -> Fluentd<'a, A> {
+        Fluentd {
+            address: address,
+            tag: tag
+        }
+    }
+
     pub fn write<B: Encodable>(&self, object: &B) -> Result<(), FluentError> {
         let tag = try!(json::encode(&self.tag));
         let now = time::now();


### PR DESCRIPTION
It would be nice to have `::new()` in `impl Fluentd`.
