### PR TITLE
tcp: Return result explicitly

### DIFF
--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -48,9 +48,12 @@ impl <'a, A: net::ToSocketAddrs> Fluentd<'a, A> {
         let message = format!("[{},{},{}]", tag, now.to_timespec().sec, record);
 
         let mut stream = try!(net::TcpStream::connect(&self.address));
-        let _ = stream.write(&message.into_bytes());
+        let result = stream.write(&message.into_bytes());
         drop(stream);
 
-        Ok(())
+        match result {
+            Ok(_) => Ok(()),
+            Err(v) => Err(From::from(v)),
+        }
     }
 }


### PR DESCRIPTION
It is awful to return `Ok(())` always. 😦
We should handle error explicitly with `Result<usize, FluentError>` -> `Result<(), FluentError>`conversion.
